### PR TITLE
add order creation and management

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,5 +1,6 @@
 from fastapi import FastAPI
 from routers.items import router as items_router
+from routers.orders import router as orders_router
 
 app = FastAPI()
 
@@ -8,3 +9,4 @@ def health():
     return {"status": "ok"}
 
 app.include_router(items_router)
+app.include_router(orders_router)

--- a/backend/app/repositories/orders_repo.py
+++ b/backend/app/repositories/orders_repo.py
@@ -1,0 +1,20 @@
+from pathlib import Path
+import json, os
+from typing import List, Dict, Any
+
+DATA_PATH = Path(__file__).resolve().parents[1] / "data" / "orders.json"
+
+
+def load_all() -> List[Dict[str, Any]]:
+    if not DATA_PATH.exists():
+        return []
+    with DATA_PATH.open("r", encoding="utf-8") as f:
+        return json.load(f)
+
+
+def save_all(orders: List[Dict[str, Any]]) -> None:
+    DATA_PATH.parent.mkdir(parents=True, exist_ok=True)
+    tmp = DATA_PATH.with_suffix(".tmp")
+    with tmp.open("w", encoding="utf-8") as f:
+        json.dump(orders, f, ensure_ascii=False, indent=2)
+    os.replace(tmp, DATA_PATH)

--- a/backend/app/routers/orders.py
+++ b/backend/app/routers/orders.py
@@ -1,0 +1,44 @@
+from fastapi import APIRouter, status
+from typing import List, Optional
+from schemas.order import Order, OrderCreate, OrderUpdate, OrderStatus
+from services.orders_service import (
+    list_orders,
+    create_order,
+    get_order_by_id,
+    update_order,
+    confirm_order,
+    cancel_order,
+)
+
+router = APIRouter(prefix="/orders", tags=["orders"])
+
+
+@router.get("", response_model=List[Order])
+def get_orders(customer_id: Optional[str] = None, status: Optional[OrderStatus] = None):
+    return list_orders(customer_id=customer_id, status=status)
+
+
+@router.post("", response_model=Order, status_code=201)
+def post_order(payload: OrderCreate):
+    return create_order(payload)
+
+
+@router.get("/{order_id}", response_model=Order)
+def get_order(order_id: str):
+    return get_order_by_id(order_id)
+
+
+@router.put("/{order_id}", response_model=Order)
+def put_order(order_id: str, payload: OrderUpdate):
+    return update_order(order_id, payload)
+
+
+@router.post("/{order_id}/confirm", response_model=Order)
+def post_confirm_order(order_id: str):
+    return confirm_order(order_id)
+
+
+@router.delete("/{order_id}", status_code=status.HTTP_204_NO_CONTENT)
+def delete_order(order_id: str):
+    cancel_order(order_id)
+    return None

--- a/backend/app/schemas/order.py
+++ b/backend/app/schemas/order.py
@@ -1,0 +1,36 @@
+from pydantic import BaseModel, Field
+from typing import List, Optional
+from enum import Enum
+
+
+class OrderStatus(str, Enum):
+    DRAFT = "draft"
+    CONFIRMED = "confirmed"
+    COMPLETED = "completed"
+    CANCELLED = "cancelled"
+
+
+class OrderItem(BaseModel):
+    food_item: str
+    quantity: int = Field(..., ge=1)
+    unit_price: float = Field(..., gt=0)
+
+
+class OrderCreate(BaseModel):
+    restaurant_id: int
+    customer_id: str
+    items: List[OrderItem] = Field(..., min_length=1)
+
+
+class OrderUpdate(BaseModel):
+    items: List[OrderItem] = Field(..., min_length=1)
+
+
+class Order(BaseModel):
+    id: str
+    restaurant_id: int
+    customer_id: str
+    items: List[OrderItem]
+    status: OrderStatus = OrderStatus.DRAFT
+    created_at: str
+    confirmed_at: Optional[str] = None

--- a/backend/app/services/orders_service.py
+++ b/backend/app/services/orders_service.py
@@ -1,0 +1,96 @@
+import uuid
+from datetime import datetime, timezone
+from typing import List, Optional
+from fastapi import HTTPException
+from schemas.order import Order, OrderCreate, OrderUpdate, OrderStatus
+from repositories.orders_repo import load_all, save_all
+
+
+def list_orders(customer_id: Optional[str] = None, status: Optional[OrderStatus] = None) -> List[Order]:
+    orders = load_all()
+    if customer_id:
+        orders = [o for o in orders if o.get("customer_id") == customer_id]
+    if status:
+        orders = [o for o in orders if o.get("status") == status.value]
+    return [Order(**o) for o in orders]
+
+
+def create_order(payload: OrderCreate) -> Order:
+    orders = load_all()
+    new_id = str(uuid.uuid4())
+    if any(o.get("id") == new_id for o in orders):
+        raise HTTPException(status_code=409, detail="ID collision; retry.")
+    new_order = Order(
+        id=new_id,
+        restaurant_id=payload.restaurant_id,
+        customer_id=payload.customer_id.strip(),
+        items=payload.items,
+        status=OrderStatus.DRAFT,
+        created_at=datetime.now(timezone.utc).isoformat(),
+    )
+    orders.append(new_order.dict())
+    save_all(orders)
+    return new_order
+
+
+def get_order_by_id(order_id: str) -> Order:
+    for o in load_all():
+        if o.get("id") == order_id:
+            return Order(**o)
+    raise HTTPException(status_code=404, detail=f"Order '{order_id}' not found")
+
+
+def update_order(order_id: str, payload: OrderUpdate) -> Order:
+    orders = load_all()
+    for idx, o in enumerate(orders):
+        if o.get("id") == order_id:
+            if o.get("status") != OrderStatus.DRAFT.value:
+                raise HTTPException(
+                    status_code=400,
+                    detail="Only draft orders can be modified.",
+                )
+            updated = Order(
+                id=order_id,
+                restaurant_id=o["restaurant_id"],
+                customer_id=o["customer_id"],
+                items=payload.items,
+                status=OrderStatus.DRAFT,
+                created_at=o["created_at"],
+            )
+            orders[idx] = updated.dict()
+            save_all(orders)
+            return updated
+    raise HTTPException(status_code=404, detail=f"Order '{order_id}' not found")
+
+
+def confirm_order(order_id: str) -> Order:
+    orders = load_all()
+    for idx, o in enumerate(orders):
+        if o.get("id") == order_id:
+            if o.get("status") != OrderStatus.DRAFT.value:
+                raise HTTPException(
+                    status_code=400,
+                    detail="Only draft orders can be confirmed.",
+                )
+            o["status"] = OrderStatus.CONFIRMED.value
+            o["confirmed_at"] = datetime.now(timezone.utc).isoformat()
+            orders[idx] = o
+            save_all(orders)
+            return Order(**o)
+    raise HTTPException(status_code=404, detail=f"Order '{order_id}' not found")
+
+
+def cancel_order(order_id: str) -> None:
+    orders = load_all()
+    for idx, o in enumerate(orders):
+        if o.get("id") == order_id:
+            if o.get("status") != OrderStatus.DRAFT.value:
+                raise HTTPException(
+                    status_code=400,
+                    detail="Only draft orders can be cancelled.",
+                )
+            o["status"] = OrderStatus.CANCELLED.value
+            orders[idx] = o
+            save_all(orders)
+            return
+    raise HTTPException(status_code=404, detail=f"Order '{order_id}' not found")


### PR DESCRIPTION
adds the order creation module (FR4). follows the same layered pattern as items.

**endpoints:**
- POST /orders - create a new order (starts as draft)
- GET /orders - list orders, can filter by customer_id and status
- GET /orders/{id} - get single order
- PUT /orders/{id} - update items in a draft order
- POST /orders/{id}/confirm - confirm and lock the order
- DELETE /orders/{id} - cancel a draft order

**business rules:**
- orders start in draft status
- only draft orders can be edited, confirmed, or cancelled
- confirming sets status to confirmed and records a timestamp

covers SR6, SR7, and US7