### PR TITLE
Ci/setup pipeline only

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,41 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r backend/app/requirements.txt
+          pip install ruff pytest-cov
+
+      - name: Run lint
+        run: ruff check backend/app --select E9,F63,F7,F82
+
+      - name: Run tests with coverage
+        working-directory: backend/app
+        run: pytest --import-mode=importlib --cov=. --cov-report=term-missing --cov-report=xml:coverage.xml tests ../test
+
+      - name: Upload coverage artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-report
+          path: backend/app/coverage.xml

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+pythonpath = backend/app
+addopts = -p no:ddtrace -p no:ddtrace.pytest_bdd -p no:ddtrace.pytest_benchmark


### PR DESCRIPTION
I've added a functioning CI workflow to run basic quality checks on every push and PR to main.
This should go through the test suite in your PR and run it to see if all tests pass.
Using Ruff instead of flake8 for the CI pipeline.

To run locally:
pip install -r backend/app/requirements.txt
pip install ruff pytest-cov
ruff check backend/app --select E9,F63,F7,F82
cd backend/app
pytest --import-mode=importlib --cov=. --cov-report=term-missing --cov-report=xml:coverage.xml tests ../test

